### PR TITLE
Remove the MPRIS initializer with argument PlayerctlPlayerName

### DIFF
--- a/Sources/MusicPlayer/Players/MPRIS.swift
+++ b/Sources/MusicPlayer/Players/MPRIS.swift
@@ -96,7 +96,7 @@ extension MusicPlayers {
             for var signal in signals {
                 g_clear_signal_handler(&signal, player)
             }
-            g_free(player)
+            g_object_unref(player)
         }
     }
 }
@@ -104,12 +104,14 @@ extension MusicPlayers {
 extension MusicPlayers.MPRIS {
     
     public class var names: [UnsafeMutablePointer<PlayerctlPlayerName>] {
-        var list = playerctl_list_players(nil)
+        let playerNames = playerctl_list_players(nil)
         var result: [UnsafeMutablePointer<PlayerctlPlayerName>] = []
-        while list != nil {
-            result.append(list!.pointee.data.assumingMemoryBound(to: PlayerctlPlayerName.self))
-            list = list!.pointee.next
+        var cur = playerNames
+        while cur != nil {
+            result.append(cur!.pointee.data.assumingMemoryBound(to: PlayerctlPlayerName.self))
+            cur = cur!.pointee.next
         }
+        g_list_free(playerNames)
         return result
     }
 }

--- a/Sources/MusicPlayer/Players/MPRISNowPlaying.swift
+++ b/Sources/MusicPlayer/Players/MPRISNowPlaying.swift
@@ -29,13 +29,14 @@ extension MusicPlayers {
             var cur = playerNames
             while (cur != nil) {
                 let playerName = cur!.pointee.data.assumingMemoryBound(to: PlayerctlPlayerName.self)
+                let name = String(cString: playerName.pointee.name)
                 let player = playerctl_player_new_from_name(playerName, nil)
                 playerctl_player_name_free(playerName)
                 if player == nil {
                     continue
                 }
                 playerctl_player_manager_manage_player(manager, player)
-                players.append(MPRIS(player: player!))
+                players.append(MPRIS(player: player!, name: name))
                 cur = cur!.pointee.next
             }
             g_list_free(playerNames)
@@ -49,7 +50,7 @@ extension MusicPlayers {
                     let `self`: MPRISNowPlaying = Unmanaged.fromOpaque(data!).takeUnretainedValue()
                     if let player = playerctl_player_new_from_name(name, nil) {
                         playerctl_player_manager_manage_player(`self`.manager, player)
-                        `self`.players.append(MPRIS(player: player))
+                        `self`.players.append(MPRIS(player: player, name: String(cString: name!.pointee.name)))
                     }
                 }
             

--- a/Sources/MusicPlayer/Utilities/Glib.swift
+++ b/Sources/MusicPlayer/Utilities/Glib.swift
@@ -40,6 +40,10 @@ public class GRunLoop {
     init(loop: OpaquePointer) {
         self.loop = loop
     }
+    
+    deinit {
+        g_main_loop_unref(loop)
+    }
 }
 
 extension GRunLoop {


### PR DESCRIPTION
The `PlayerctlPlayerName` should not be exposed to `MusicPlayer` users.

By the way, the `Windows.Media.Control.GlobalSystemMediaTransportControlsSession` required on Windows.
Sadly, it's a WinRT API which not bridged in the swift `WinSDK`.